### PR TITLE
Add a new icu_format Twig filter

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -29,3 +29,9 @@ services:
 
     webfactory_icu_translation.formatter:
         alias: webfactory_icu_translation.formatter.graceful_exceptions
+
+    webfactory_icu_translation.twig_extension:
+        class: Webfactory\IcuTranslationBundle\Twig\IcuFormattingExtension
+        arguments: ["@webfactory_icu_translation.formatter.intl_formatter", "@translator"]
+        tags:
+            - { name: twig.extension }

--- a/Twig/IcuFormattingExtension.php
+++ b/Twig/IcuFormattingExtension.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Webfactory\IcuTranslationBundle\Twig;
+
+use Symfony\Component\Translation\TranslatorInterface;
+use Webfactory\IcuTranslationBundle\Translator\Formatting\FormatterInterface;
+
+class IcuFormattingExtension extends \Twig_Extension
+{
+    /**
+     * @var FormatterInterface
+     */
+    private $formatter;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(FormatterInterface $formatter, TranslatorInterface $translator)
+    {
+        $this->formatter = $formatter;
+        $this->translator = $translator;
+    }
+
+    public function getFilters()
+    {
+        return [
+            new \Twig_SimpleFilter('icu_format', [$this, 'format']),
+        ];
+    }
+
+    public function format($message = '', $parameters = [], $locale = null)
+    {
+        return $this->formatter->format($locale ?: $this->translator->getLocale(), $message, $parameters);
+    }
+}


### PR DESCRIPTION
The filter takes an optional parameters argument as well as a locale
and applies the ICU formatting rules to its input string.

Example:

`{{ '{name} will arrive shortly.' | icu_format({name: 'Peter'}) }}`