### PR TITLE
Add `icu_format` Twig filter

### DIFF
--- a/Twig/IcuFormattingExtension.php
+++ b/Twig/IcuFormattingExtension.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Webfactory\IcuTranslationBundle\Twig;
+
+use Symfony\Component\Translation\TranslatorInterface;
+use Webfactory\IcuTranslationBundle\Translator\Formatting\FormatterInterface;
+
+class IcuFormattingExtension extends \Twig_Extension
+{
+    /**
+     * @var FormatterInterface
+     */
+    private $formatter;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(FormatterInterface $formatter, TranslatorInterface $translator)
+    {
+        $this->formatter = $formatter;
+        $this->translator = $translator;
+    }
+
+    public function getFilters()
+    {
+        return [
+            new \Twig_SimpleFilter('icu_format', [$this, 'format']),
+        ];
+    }
+
+    public function format($message = '', $parameters = [], $locale = null)
+    {
+        return $this->formatter->format($locale ?: $this->translator->getLocale(), $message, $parameters);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,15 @@
         "symfony/dependency-injection": "^3.4.31|^4.0",
         "symfony/finder": "^3.4.31|^4.0",
         "symfony/http-kernel": "^3.4.31|^4.0",
-        "symfony/translation": "^3.4.31|^4.0"
+        "symfony/translation": "^3.4.31|^4.0",
+        "twig/twig": "^1.42|^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 | ^9.0",
         "symfony/framework-bundle": "^3.4.31|^4.0",
         "symfony/monolog-bundle": "^3.4.31|^4.0",
         "symfony/phpunit-bridge": "> 5.0",
+        "symfony/twig-bundle": "^3.4.31|^4.0",
         "symfony/yaml": "^4.4"
     },
     "autoload": {

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -6,6 +6,9 @@ services:
     Webfactory\IcuTranslationBundle\Translator\Formatting\:
         resource: '../../Translator/Formatting/*.php'
 
+    Webfactory\IcuTranslationBundle\Twig\:
+        resource: '../../Twig'
+
     webfactory_icu_translation.formatter.intl_formatter:
         alias: Webfactory\IcuTranslationBundle\Translator\Formatting\IntlFormatter
         deprecated: ~

--- a/src/Twig/IcuFormattingExtension.php
+++ b/src/Twig/IcuFormattingExtension.php
@@ -3,9 +3,11 @@
 namespace Webfactory\IcuTranslationBundle\Twig;
 
 use Symfony\Component\Translation\TranslatorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 use Webfactory\IcuTranslationBundle\Translator\Formatting\FormatterInterface;
 
-class IcuFormattingExtension extends \Twig_Extension
+class IcuFormattingExtension extends AbstractExtension
 {
     /**
      * @var FormatterInterface
@@ -26,11 +28,11 @@ class IcuFormattingExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('icu_format', [$this, 'format']),
+            new TwigFilter('icu_format', [$this, 'format']),
         ];
     }
 
-    public function format($message = '', $parameters = [], $locale = null)
+    public function format(string $message = '', array $parameters = [], string $locale = null): string
     {
         return $this->formatter->format($locale ?: $this->translator->getLocale(), $message, $parameters);
     }

--- a/tests/Fixtures/TestKernel.php
+++ b/tests/Fixtures/TestKernel.php
@@ -4,6 +4,7 @@ namespace Webfactory\IcuTranslationBundle\Tests\Fixtures;
 
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
@@ -26,6 +27,7 @@ final class TestKernel extends Kernel
         return [
             new FrameworkBundle(),
             new WebfactoryIcuTranslationBundle(),
+            new TwigBundle(),
         ];
     }
 

--- a/tests/Functional/TwigExtensionTest.php
+++ b/tests/Functional/TwigExtensionTest.php
@@ -24,10 +24,21 @@ class TwigExtensionTest extends KernelTestCase
 
     /**
      * @test
+     * @dataProvider provideTranslationMessages
      */
-    public function icu_format_filter_expands_parameters_in_curly_braced(): void
+    public function icu_format_filter_expands_parameters_in_curly_braces(string $expected, string $twigCode): void
     {
-        self::assertSame('Peter will arrive shortly.', $this->renderTemplate('{{ "{name} will arrive shortly." | icu_format({name: "Peter"}) }}'));
+        self::assertSame($expected, $this->renderTemplate($twigCode));
+    }
+
+    public function provideTranslationMessages(): iterable
+    {
+        yield 'no-op translation' => ['test', '{{ "test" |icu_format }}'];
+        yield 'substitute placeholders with curly braces' => ['test', '{{ "{param}" |icu_format({ param: "test" }) }}'];
+
+        // Parameters passed may be surrounded by '%' signs (why is that a use-case? https://symfony.com/doc/current/translation.html#message-format)
+        // and should be recognized anyway.
+        yield 'strip percent signs from parameter names' => ['test', '{{ "{param}" |icu_format({ "%param%": "test" }) }}'];
     }
 
     private function renderTemplate(string $template): string

--- a/tests/Functional/TwigExtensionTest.php
+++ b/tests/Functional/TwigExtensionTest.php
@@ -39,6 +39,9 @@ class TwigExtensionTest extends KernelTestCase
         // Parameters passed may be surrounded by '%' signs (why is that a use-case? https://symfony.com/doc/current/translation.html#message-format)
         // and should be recognized anyway.
         yield 'strip percent signs from parameter names' => ['test', '{{ "{param}" |icu_format({ "%param%": "test" }) }}'];
+
+        yield 'locale is used to format a number in the German locale' => ['3,141', '{{ "{param,number}" |icu_format({ param: 3.141 }, "de") }}'];
+        yield 'locale is used to format a number in the English locale' => ['3.141', '{{ "{param,number}" |icu_format({ param: 3.141 }, "en") }}'];
     }
 
     private function renderTemplate(string $template): string

--- a/tests/Functional/TwigExtensionTest.php
+++ b/tests/Functional/TwigExtensionTest.php
@@ -42,6 +42,9 @@ class TwigExtensionTest extends KernelTestCase
 
         yield 'locale is used to format a number in the German locale' => ['3,141', '{{ "{param,number}" |icu_format({ param: 3.141 }, "de") }}'];
         yield 'locale is used to format a number in the English locale' => ['3.141', '{{ "{param,number}" |icu_format({ param: 3.141 }, "en") }}'];
+
+        yield 'using select expressions' => ['A was used', '{{ "{param, select, a {A was used} other {something else}}" |icu_format({ param: "a"}) }}'];
+
     }
 
     private function renderTemplate(string $template): string

--- a/tests/Functional/TwigExtensionTest.php
+++ b/tests/Functional/TwigExtensionTest.php
@@ -44,7 +44,6 @@ class TwigExtensionTest extends KernelTestCase
         yield 'locale is used to format a number in the English locale' => ['3.141', '{{ "{param,number}" |icu_format({ param: 3.141 }, "en") }}'];
 
         yield 'using select expressions' => ['A was used', '{{ "{param, select, a {A was used} other {something else}}" |icu_format({ param: "a"}) }}'];
-
     }
 
     private function renderTemplate(string $template): string

--- a/tests/Functional/TwigExtensionTest.php
+++ b/tests/Functional/TwigExtensionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Webfactory\IcuTranslationBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+
+class TwigExtensionTest extends KernelTestCase
+{
+    /**
+     * @var Environment
+     */
+    protected $twig;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $kernel = static::bootKernel();
+        $container = $kernel->getContainer();
+
+        $this->twig = $container->get('twig');
+    }
+
+    /**
+     * @test
+     */
+    public function icu_format_filter_expands_parameters_in_curly_braced(): void
+    {
+        self::assertSame('Peter will arrive shortly.', $this->renderTemplate('{{ "{name} will arrive shortly." | icu_format({name: "Peter"}) }}'));
+    }
+
+    private function renderTemplate(string $template): string
+    {
+        $template = $this->twig->createTemplate($template);
+
+        return $this->twig->render($template);
+    }
+}


### PR DESCRIPTION
This adds a new `icu_format` Twig filter that can be used to apply ICU-based formatting to given messages.

Examples:

* `{{ '{name} will arrive shortly.' | icu_format({name: 'Peter'}) }}`
* `{{ '{gender, select, male {{name} invited you to his party!} female {{name} invited you to her party!}}' | icu_format({ gender: 'female', name: 'Jane' }) }}`

This closes #24.