### PR TITLE
Implement new interfaces from symfony/translation-contracts

### DIFF
--- a/.github/workflows/lock-symfony-version.sh
+++ b/.github/workflows/lock-symfony-version.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cat <<< $(jq --arg version $VERSION '.require  |= with_entries(if ((.key|test("^symfony/monolog")|not) and (.key|test("^symfony/"))) then .value=$version else . end)' < composer.json) > composer.json
+cat <<< $(jq --arg version $VERSION '.require  |= with_entries(if ((.key|test("^symfony/translation-contracts")|not) and (.key|test("^symfony/"))) then .value=$version else . end)' < composer.json) > composer.json

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 | ^9.0",
-        "symfony/framework-bundle": "^3.4.31|^4.0",
         "symfony/monolog-bundle": "^3.4.31|^4.0",
         "symfony/phpunit-bridge": "> 5.0",
         "symfony/twig-bundle": "^3.4.31|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,10 @@
         "symfony/config": "^3.4.31|^4.0",
         "symfony/dependency-injection": "^3.4.31|^4.0",
         "symfony/finder": "^3.4.31|^4.0",
+        "symfony/framework-bundle": "^4.4",
         "symfony/http-kernel": "^3.4.31|^4.0",
-        "symfony/translation": "^3.4.31|^4.0",
+        "symfony/translation": "^4.2",
+        "symfony/translation-contracts": "^1.0.2|^2.0|^3.0",
         "twig/twig": "^1.42|^2.0|^3.0"
     },
     "require-dev": {

--- a/src/Translator/FormatterDecorator.php
+++ b/src/Translator/FormatterDecorator.php
@@ -2,34 +2,35 @@
 
 namespace Webfactory\IcuTranslationBundle\Translator;
 
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Webfactory\IcuTranslationBundle\Translator\Formatting\FormatterInterface;
 
 /**
  * Decorates a Symfony translator and adds support for message formatting.
  */
-class FormatterDecorator implements TranslatorInterface
+class FormatterDecorator implements LegacyTranslatorInterface, TranslatorInterface
 {
     /**
      * The inner translator.
      *
      * @var \Symfony\Component\Translation\TranslatorInterface
      */
-    protected $translator = null;
+    protected $translator;
 
     /**
      * The formatter that is used to apply message transformations.
      *
      * @var \Webfactory\IcuTranslationBundle\Translator\Formatting\IntlFormatter
      */
-    protected $formatter = null;
+    protected $formatter;
 
     /**
      * Creates a decorator for the provided translator.
      *
      * @param \Webfactory\IcuTranslationBundle\Translator\Formatting\FormatterInterface the formatter that is used
      */
-    public function __construct(TranslatorInterface $translator, FormatterInterface $formatter)
+    public function __construct(LegacyTranslatorInterface $translator, FormatterInterface $formatter)
     {
         $this->translator = $translator;
         $this->formatter = $formatter;


### PR DESCRIPTION
Symfony 4.2 deprecated `\Symfony\Component\Translation\TranslatorInterface` in favor of `\Symfony\Contracts\Translation\TranslatorInterface`.

This PR implements the new interfaces in addition to the old ones to allow for a smoother transition.